### PR TITLE
Fix CentOS hda-install erroring

### DIFF
--- a/hda-install
+++ b/hda-install
@@ -471,7 +471,7 @@ def start_all_services
 end
 
 def start_service(service)
-	if fedora?
+	if fedora? or centos?
 		do_system "/usr/bin/systemctl start #{service}.service"
 	elsif ubuntu? and File.exist?(UPSTART_CONF % service)
 		do_system "/sbin/initctl start #{service}"


### PR DESCRIPTION
This will fix hda-install from exiting uncleanly on CentOS.