### PR TITLE
Update hda-install

### DIFF
--- a/hda-install
+++ b/hda-install
@@ -51,13 +51,16 @@ OLDOUT = $stdout.dup
 
 def set_platform
     issue = nil
-    if File.exists?('/etc/system-release')
+    if File.exists?('/etc/amahi-release')
+	file = nil   
+	issue = File.open("/etc/amahi-release", "r")
+    elsif File.exists?('/etc/system-release')
 	file = nil
 	issue = File.open("/etc/system-release", "r")
     elsif File.exists?('/etc/issue')
 	issue = File.open("/etc/issue", "r")
     else
-	raise "Ohhh. System not known. Sowwy."
+	raise "Ohhh. System not known. Sorry."
     end
     line = issue.gets;
     $platform = "unknown";

--- a/hda-install
+++ b/hda-install
@@ -542,6 +542,7 @@ def check_install_code(inst_code)
 	url = "https://api.amahi.org/api2/install/#{inst_code}?os=#{os}&arch=#{arch}&ver=#{$version}"
 
 	@system_configuration = nil
+        file = File.open('/root/system_config')
 
 	message "Retrieving install code ..."
 
@@ -550,6 +551,7 @@ def check_install_code(inst_code)
 	(1..3).each do
 		begin
 			@system_configuration = open(url, "User-Agent" => "ruby/#{RUBY_VERSION}").read
+                       
 		rescue
 			sleep time
 			time += 1
@@ -581,7 +583,6 @@ def check_install_code(inst_code)
 
 	if @system_configuration =~ /^error: unknown code$/
 		puts @system_configuration
-		# message @system_configuration
 		message "ERROR: install code '#{inst_code}' is not a valid install code."
 		exit(-1)
 	elsif @system_configuration_length == 0
@@ -591,10 +592,10 @@ def check_install_code(inst_code)
 	message "Install code looks good"
 end
 
-def copy_remote_db_configuration(hda)
+def copy_remote_db_configuration()
 
 	if @system_configuration_length == 0
-		abort "hda-install: ERROR: configuration for install code '" + hda + "' is empty."
+		abort "hda-install: ERROR: configuration for install code is empty."
 	end
 
 	begin
@@ -611,7 +612,7 @@ end
 
 def do_db(install_code)
 	puts "Syncing settings for #{install_code} ... "
-	copy_remote_db_configuration install_code
+	copy_remote_db_configuration
 	puts "Syncing settings done."
 end
 
@@ -776,7 +777,7 @@ def link_apaste
 end
 
 
-def do_full_install(hda)
+def do_full_install()
 
 	if fedora? or centos?
 		selinux_permissive
@@ -840,7 +841,7 @@ def do_full_install(hda)
 
 	# update DB with remote data
 	message "Activating your HDA's settings"
-	copy_remote_db_configuration hda
+	copy_remote_db_configuration
 
 	sleep 1
 
@@ -1213,6 +1214,17 @@ def set_standard_out
 	message "Verbose log file at '#{logfile}'."
 end
 
+def copy_system_configuration
+        if File.exists?('/etc/system_configuration_amahi')
+                     file = File.open('/etc/system_configuration_amahi')              
+                     @system_configuration = file.read
+                     @system_configuration_length = @system_configuration.size
+        else
+                     message "ERROR - Amahi Server configuration not found in /etc/"
+                     exit 1
+        end
+end                             
+
 def do_basic_checks
 	ENV["PATH"] += ":/sbin:/usr/sbin:/bin"
 
@@ -1245,7 +1257,7 @@ def do_basic_checks
 		rescue
 			g = nil
 		end
-
+               
 		unless g
 			(1..3).each do
 				do_system_silent "service monit stop"
@@ -1275,7 +1287,7 @@ end
 
 def main
 	version if @opt["V"]
-
+  
 	if @opt["o"]
 		set_standard_out
 		if fedora? or centos?
@@ -1284,15 +1296,19 @@ def main
 		exit 0
 	end
 
-	usage unless ARGV.size > 0
-
-	inst_code = ARGV[0]
-
+	#usage unless ARGV.size > 0
+        
 	do_basic_checks
 
 	set_standard_out
 
-	check_install_code inst_code
+        #to support both INSTALL CODE or no INSTALL CODE
+        if ARGV.size > 0 && ARGV[0].length > 4
+	              inst_code = ARGV[0]
+                      check_install_code inst_code
+        else 
+                      copy_system_configuration
+        end
 
 	if @opt["s"] || @opt["d"] ||
 		@opt["n"] || @opt["h"] || @opt["w"] || @opt["o"]
@@ -1310,8 +1326,8 @@ def main
 
 		return
 	end
-
-	do_full_install inst_code
+        
+	do_full_install
 end
 
 main

--- a/hda-install
+++ b/hda-install
@@ -542,8 +542,6 @@ def check_install_code(inst_code)
 	url = "https://api.amahi.org/api2/install/#{inst_code}?os=#{os}&arch=#{arch}&ver=#{$version}"
 
 	@system_configuration = nil
-        file = File.open('/root/system_config')
-
 	message "Retrieving install code ..."
 
 	time = 3
@@ -1266,7 +1264,7 @@ def do_basic_checks
 				do_system_silent "killall dhclient"
 				do_system_silent "service " + NAMED_SERVERNAME + " stop"
 				sleep 1
-				do_system_silent "dhclient eth0"
+				do_system_silent "dhclient"
 				sleep 1
 				begin
 					g = open('http://www.yahoo.com/').read

--- a/hda-install
+++ b/hda-install
@@ -47,7 +47,7 @@ LEGACY_INIT_PATH = "/etc/init.d/"
 
 OLDOUT = $stdout.dup
 
-@opt = ARGV.getopts("VfsdrDhnwmoyqi:p")
+@opt = ARGV.getopts("VfusdrDhnwmoyqi:p")
 
 def set_platform
     issue = nil
@@ -596,7 +596,7 @@ end
 def copy_remote_db_configuration()
 
 	if @system_configuration_length == 0
-		abort "hda-install: ERROR: configuration for install code is empty."
+		abort "hda-install: ERROR: @system_configuration is empty."
 	end
 
 	begin
@@ -1158,7 +1158,8 @@ end
 
 def usage
 
-	puts "usage: hda-install [options] YOUR_INSTALL_CODE"
+	puts "usage: hda-install [options]... [YOUR_INSTALL_CODE]... "
+        puts "Setup Amahi Server, either from 'system_configuration_amahi' file in '/etc' OR from INSTALL_CODE"
 	puts " options:"
 	puts "  -f: force"
 	puts "  -r: exclude ruby install"
@@ -1173,6 +1174,7 @@ def usage
 	puts "  -i device: use this interface for networking (default: #{@network_device})"
 	puts "  -p: VPS mode"
 	puts "  -V: version"
+        puts "  -u: usage"
 	exit(-1)
 end
 
@@ -1221,7 +1223,7 @@ def copy_system_configuration
                      @system_configuration = file.read
                      @system_configuration_length = @system_configuration.size
         else
-                     message "ERROR - Amahi Server configuration not found in /etc/"
+                     message "ERROR - system_configuration_amahi file not found in /etc/"
                      exit 1
         end
 end                             
@@ -1297,7 +1299,7 @@ def main
 		exit 0
 	end
 
-	#usage unless ARGV.size > 0
+	usage if @opt["u"]
         
 	do_basic_checks
 


### PR DESCRIPTION
Added support for both INSTALL CODE or with provided system_configuration

Instead of getting network data (ip address, apikey, gateway, etc) from INSTALL CODE, it will get data directly from `/etc/system_configuration_amahi` file. This file will be provided during the `fedora` installation after the user enters the correct username/password. 

For backward compatibility, I have added - https://github.com/amahi/hda-ctl/pull/5/commits/ada22c968d31b60f602633a7bdde92515c9bf011#diff-fb8d6b0270ad8facb9983759f9e8eafaR1305 
, which means if INSTALL CODE (or any arguments) are provided then it will work in old-fashion way. 

It will not intefare with normal operation of script. Tested thoroughly.