### PR TITLE
Update hda-ctl

### DIFF
--- a/hda-ctl
+++ b/hda-ctl
@@ -1056,6 +1056,16 @@ sub basic_checks {
 }
 
 sub get_platform {
+
+
+        if (open (my $file, "< /etc/amahi-release")) {
+		my $p = <$file>;
+	        chomp $p;
+	        return "fedora" if ($p =~ /Fedora/);
+	        return "debian" if ($p =~ /Debian/);
+	        return "ubuntu" if ($p =~ /Ubuntu/);
+	}
+
 	open (my $file, "< /etc/system-release") or return "unknown";
 	my $p = <$file>;
 	chomp $p;


### PR DESCRIPTION
Just saw `hda-ctl` taking `platform` from `system-release`. So, added for `amahi-release`.
Maybe, better to push it to f27 also. @cpg