### PR TITLE
Update hda-change-network

### DIFF
--- a/hda-change-network
+++ b/hda-change-network
@@ -75,6 +75,12 @@ def setup_network_manager(ip, gw, dns1, dns2)
 	if ethernet
 		s = ethernet["org.freedesktop.NetworkManager.Settings.Connection"].GetSettings
 		new_settings = s[0].merge(con)
+		# FIXME we're not sure why this needs to be done now to avoid dbus exceptions
+		new_settings["connection"].delete 'permissions'
+		new_settings["connection"].delete 'secondaries'
+		new_settings["connection"].delete 'mac-address'
+		new_settings.delete "802-3-ethernet"
+		new_settings.delete "ipv6"
 		ethernet["org.freedesktop.NetworkManager.Settings.Connection"].Update(new_settings)
 	else
 		# if we have not found an ethernet connection configured, create one


### PR DESCRIPTION
Just found this while debugging `hda-ctl`. `hda-ctl` use `hda-change-network` to change network but `hda-change-network` was throwing some exceptions.
Then I checked this - https://github.com/amahi/hda-ctl/blob/94fb342d33dd40ea63d776727e31b6b3f1611884/hda-install#L991 
and fixed the exceptions, just in case.