### PR TITLE
Added "domain-search" dhcp-option

### DIFF
--- a/hda-ctl
+++ b/hda-ctl
@@ -916,6 +916,7 @@ sub print_dnsmasq_dhcp_conf {
 		} else {
 			printf $dnsmasq "dhcp-option=option:dns-server,%s,%s\n", $dns1, $dns1;
 		}
+		printf $dnsmasq "dhcp-option=option:domain-search,%s\n", $domain;
 
 		# FEATURE: do not mess with tftp for now
 		# printf $dnsmasq "dhcp-option=option:tftp-server,\"%s\"\n", $self;


### PR DESCRIPTION
Will make it easier to use the host (without domain) when querying in the network. Without this option, the default "domain-search" is "home", so when one tries to access "http://hda", the host will query "hda.home" to dnsmasq, which doesn't exist.